### PR TITLE
Fixed base prefix for default subscriptions

### DIFF
--- a/bcg/gateway.py
+++ b/bcg/gateway.py
@@ -30,7 +30,7 @@ class Gateway:
         self._cache_nodes = {}
         self._info = None
         self._info_id = None
-        self._sub = set([config['base_topic_prefix'] + 'gateway/ping', config['base_topic_prefix'] + 'gateway/all/info/get'])
+        self._sub = set(['gateway/ping', 'gateway/all/info/get'])
         self._nodes = {}
 
         self._auto_rename_nodes = self._config['automatic_rename_nodes'] or self._config['automatic_rename_kit_nodes'] or self._config['automatic_rename_generic_nodes']


### PR DESCRIPTION
The `mqtt_on_connect` method expects that `self._sub` contains **not prefixed** topics as it adds the the prefix later when it [calls `client.subscribe`](https://github.com/bigclownlabs/bch-gateway/blob/master/bcg/gateway.py#L170). Other methods such as [`sub_remove`](https://github.com/bigclownlabs/bch-gateway/blob/master/bcg/gateway.py#L371) expect the prefix is added to the topic internally. Therefore it makes no sense to prefix topics that early.