### PR TITLE
Add command line option to retain MQTT messages from nodes

### DIFF
--- a/bcg/__init__.py
+++ b/bcg/__init__.py
@@ -27,11 +27,12 @@ log_level_lut = {'D': 'debug', 'I': 'info', 'W': 'warning', 'E': 'error'}
 @click.option('--mqtt-cafile', help='MQTT cafile')
 @click.option('--mqtt-certfile', help='MQTT certfile')
 @click.option('--mqtt-keyfile', help='MQTT keyfile')
+@click.option('--retain-node-messages', is_flag=True, help='Set the MQTT retain flag for messages received from nodes')
 @click_log.simple_verbosity_option(default='INFO')
 @click.option('--debug', '-D', is_flag=True, help='Print debug messages, same as --verbosity DEBUG.')
 @click.version_option(version=__version__)
 @click.pass_context
-def cli(ctx, config_file, device, mqtt_host, mqtt_port, no_wait, mqtt_username, mqtt_password, mqtt_cafile, mqtt_certfile, mqtt_keyfile, debug):
+def cli(ctx, config_file, device, mqtt_host, mqtt_port, no_wait, mqtt_username, mqtt_password, mqtt_cafile, mqtt_certfile, mqtt_keyfile, retain_node_messages, debug):
     '''BigClown gateway between USB serial port and MQTT broker'''
 
     if debug:
@@ -65,6 +66,9 @@ def cli(ctx, config_file, device, mqtt_host, mqtt_port, no_wait, mqtt_username, 
 
     if mqtt_keyfile:
         config['mqtt']['keyfile'] = mqtt_keyfile
+
+    if retain_node_messages:
+        config['retain'] = retain_node_messages
 
     if not config.get('device', None):
         click.echo('The following arguments are required: -d/--device or -c/--config')

--- a/bcg/gateway.py
+++ b/bcg/gateway.py
@@ -45,6 +45,8 @@ class Gateway:
         self.mqttc.message_callback_add(config['base_topic_prefix'] + "gateway/ping", self.gateway_ping)
         self.mqttc.message_callback_add(config['base_topic_prefix'] + "gateway/all/info/get", self.gateway_all_info_get)
 
+        self._retain = config.get('retain', False)
+
         self.mqttc.username_pw_set(config['mqtt'].get('username'), config['mqtt'].get('password'))
         if config['mqtt'].get('cafile'):
             self.mqttc.tls_set(config['mqtt'].get('cafile'), config['mqtt'].get('certfile'), config['mqtt'].get('keyfile'))
@@ -321,7 +323,7 @@ class Gateway:
             if node_name:
                 subtopic = node_name + '/' + topic
 
-            self.mqttc.publish(self._config['base_topic_prefix'] + "node/" + subtopic, json.dumps(payload, use_decimal=True), qos=1)
+            self.mqttc.publish(self._config['base_topic_prefix'] + "node/" + subtopic, json.dumps(payload, use_decimal=True), qos=1, retain=self._retain)
 
         except Exception:
             raise


### PR DESCRIPTION
This patch adds a new command line option called --retain-node-messages. When enabled, the MQTT client in the gateway will set the MQTT retain flag on published messages that come from nodes. Messages published to other topics (e.g., gateway/) will not be affected by this flag and will have the MQTT retain flag unset.

Since many (if not most) topics that originate from Hardwario nodes represent environmental and other parameters that are sampled and published infrequently, it might be useful to enable the MQTT retain flag for such messages so that the MQTT broker can remember the most recent value for each such topic. A newly connected or reconnecting MQTT subscriber would then receive the most recent value immediately upon connecting and would not need to wait for another update which may take minutes, hours, or even days to arrive.