### PR TITLE
Minor improvements to systemd and udev configuration files

### DIFF
--- a/config/50-bc-gateway-core-module.rules
+++ b/config/50-bc-gateway-core-module.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", ACTION=="add", KERNEL=="ttyUSB*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ATTRS{serial}=="hio-core-module*", SYMLINK+="bcCore%n", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/bcCore%n", ENV{SYSTEMD_WANTS}="bc-gateway-core-module@bcCore%n.service"

--- a/config/bc-gateway-core-module@.service
+++ b/config/bc-gateway-core-module@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=BigClown gateway between core module connected via USB (/dev/%I) and MQTT broker
+StartLimitIntervalSec=0
+StopWhenUnneeded=true
+After=network.target mosquitto.service
+Requires=mosquitto.service
+
+[Service]
+ExecStart=/usr/local/bin/bcg --no-wait -d /dev/%I -c /etc/bigclown/bc-gateway-core-module.yml
+User=root
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target
+

--- a/config/bc-gateway-usb-dongle@.service
+++ b/config/bc-gateway-usb-dongle@.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=BigClown gateway between Base unit connected via USB (/dev/%I) and MQTT broker
+Description=BigClown gateway between radio dongle connected via USB (/dev/%I) and MQTT broker
 StartLimitIntervalSec=0
 StopWhenUnneeded=true
-After=network.target
+After=network.target mosquitto.service
 
 [Service]
 ExecStart=/usr/local/bin/bcg --no-wait -d /dev/%I -c /etc/bigclown/bc-gateway-usb-dongle.yml


### PR DESCRIPTION
This pull request primarily adds a udev rule file for core modules serving as radio dongles. It also adds a corresponding systemd unit template that could be used to start or stop the gateway as a core module is connected or disconnected (triggered by the udev rule file).