### PR TITLE
bcg: gateway: use Python's built-in json library

### DIFF
--- a/bcg/gateway.py
+++ b/bcg/gateway.py
@@ -3,7 +3,7 @@
 import os
 import time
 import logging
-import simplejson as json
+import json
 import platform
 import socket
 import decimal

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ click-log>=0.2.1
 paho-mqtt>=1.0     # deb:python3-paho-mqtt>=1.0
 pyserial>=3.0      # deb:python3-serial>=3.0
 PyYAML>=3.11       # deb:python3-yaml>=3.11
-simplejson>=3.6.0  # deb:python3-simplejson>=3.6.0
 schema>=0.6
 appdirs>=1.0


### PR DESCRIPTION
This reduces the dependency list by one, since Python has a built-in JSON
library with the same API.

Fixes #16 

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>