### PR TITLE
bcg: fix import with Python 3.12

### DIFF
--- a/bcg/__init__.py
+++ b/bcg/__init__.py
@@ -4,7 +4,6 @@ import sys
 import os
 import click
 import click_log
-from distutils.version import LooseVersion
 import logging
 from bcg.gateway import Gateway
 from bcg.utils import *

--- a/bcg/utils.py
+++ b/bcg/utils.py
@@ -5,7 +5,7 @@ import sys
 import serial
 import click
 import platform
-from distutils.version import LooseVersion
+from  looseversion import LooseVersion
 
 pyserial_34 = LooseVersion(serial.VERSION) >= LooseVersion("3.4.0")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyserial>=3.0      # deb:python3-serial>=3.0
 PyYAML>=3.11       # deb:python3-yaml>=3.11
 schema>=0.6
 appdirs>=1.0
+looseversion


### PR DESCRIPTION
Package distutils was removed with this cpython version. Package looseversion is used instead to provide the same functionality.